### PR TITLE
Move all template bindings into ngOnInit

### DIFF
--- a/projects/angular-pharkas/README.md
+++ b/projects/angular-pharkas/README.md
@@ -157,10 +157,6 @@ export class MyExampleComponent extends PharkasComponent<MyExampleComponent> {
     // Build some observables…
 
     this.bind('testDisplay', someObservable, 'Default Value')
-    // …other bindings…
-
-    // Finally, wire the main template subscription
-    this.wire()
   }
 }
 ```

--- a/projects/angular-pharkas/package.json
+++ b/projects/angular-pharkas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pharkas",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "peerDependencies": {
     "@angular/common": "^11.1.1",
     "@angular/core": "^11.1.1"

--- a/src/app/pharkas-test.component.ts
+++ b/src/app/pharkas-test.component.ts
@@ -70,8 +70,6 @@ export class PharkasTestComponent extends PharkasComponent<PharkasTestComponent>
     // Dumb console log test of handleClick
     this.bindEffect(click, ([mouseEvent]) => console.log('clicked', mouseEvent))
 
-    this.wire()
-
     console.log(this)
   }
 }


### PR DESCRIPTION
- Removes the need for a manual `this.wire()`
- Helps avoid Angular's "should be run in update mode" assertion when ChangeDetectorRef.detectChanges() is called before ngOnInit