### PR TITLE
Make input binding even more direct

### DIFF
--- a/projects/angular-pharkas/README.md
+++ b/projects/angular-pharkas/README.md
@@ -81,7 +81,7 @@ export class MyExampleComponent extends PharkasComponent<MyExampleComponent> {
   constructor(ref: ChangeDetectorRef) {
     super(ref)
 
-    const testInput = this.useInput('testInput')
+    const testInput = this.useInput('testInput', 'Hello World')
 
     // Use testInput to build observable pipelines…
   }

--- a/projects/angular-pharkas/package.json
+++ b/projects/angular-pharkas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pharkas",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "peerDependencies": {
     "@angular/common": "^11.1.1",
     "@angular/core": "^11.1.1"

--- a/src/app/pharkas-test.component.ts
+++ b/src/app/pharkas-test.component.ts
@@ -48,7 +48,7 @@ export class PharkasTestComponent extends PharkasComponent<PharkasTestComponent>
     super(ref)
 
     // Show the test input in testDisplay
-    const testInput = this.useInput('test')
+    const testInput = this.useInput('test', 'World')
     this.bind('testDisplay', testInput, 'World')
 
     // Bind DOM click to Output Mickey via callback handleClick


### PR DESCRIPTION
Use a direct BehaviorSubject<T>, and subscribe inputs directly to it. Puts useInput entirely in charge of createInput and changes the useInput signature to directly require a default value for the BehaviorSubject.