### PR TITLE
Ensure all of our subscribers are artisanal with proper closures

### DIFF
--- a/projects/angular-pharkas/package.json
+++ b/projects/angular-pharkas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pharkas",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "peerDependencies": {
     "@angular/common": "^11.1.1",
     "@angular/core": "^11.1.1"


### PR DESCRIPTION
RxJS clones subscribers if it doesn't think they are "safe" and Zone's fucking monkey-patching to Subjects makes them seem not safe so any state mechanics, which you know are the point of BehaviorSubject and ReplaySubject, *break*.

So, ensure all of our subscribers are artisanal and our arrow function closures should update the shared subjects and not voodoo clone subjects.