### PR TITLE
Ignore but warn of completion of input observables

### DIFF
--- a/projects/angular-pharkas/package.json
+++ b/projects/angular-pharkas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pharkas",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "peerDependencies": {
     "@angular/common": "^11.1.1",
     "@angular/core": "^11.1.1"


### PR DESCRIPTION
This matches the documented (and already partially warned) intended behavior, so considering this a semver minor break rather than semver major, despite it being a major behavior change.