### PR TITLE
⛓ Change template binding behavior

### DIFF
--- a/projects/angular-pharkas/package.json
+++ b/projects/angular-pharkas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pharkas",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "peerDependencies": {
     "@angular/common": "^11.1.1",
     "@angular/core": "^11.1.1"


### PR DESCRIPTION
Angular really doesn't want us to throw errors from template variables and it breaks things like the "blinkenlights", so let's not throw errors from template-intended BehaviorSubjects.

It's another major behavior change under the hood, but because the new behavior should align better with the documented expectations I'm again leaving it only a semver minor change.