### PR TITLE
🔗 Add support for default input bindings to service class observables

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,24 @@ export class … {
 
 It will give you console warnings in development builds for non-Observable inputs.
 
+`this.useInput` accepts as an optional second parameter a default value or a function that returns a default
+Observable if an Observable was not bound to the input property prior to `ngOnInit`.
+
+```ts
+export class … {
+  constructor(ref: ChangeDetectorRef, service: SomeService) {
+    super(ref)
+
+    const testInput = this.useInput('testInput', () => service.GetSomeObservable())
+
+    // Use testInput to build observable pipelines…
+  }
+}
+```
+
+Note that using a service class dependency adds tighter coupling for what may be more useful as an always
+provided input, which would be looser coupled.
+
 Also, yeah the string property names and duplication isn't great, but we are working with what Angular gives us.
 
 ## Template Bindings (View Variables, Display Slots, Whatever You Call Them)

--- a/docs/classes/PharkasComponent.md
+++ b/docs/classes/PharkasComponent.md
@@ -67,7 +67,7 @@ inspirations from ReactiveUI (.NET) and React's Hook components.
 
 #### Defined in
 
-[pharkas.component.ts:166](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L166)
+[pharkas.component.ts:167](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L167)
 
 ## Accessors
 
@@ -83,7 +83,7 @@ An observable notifying when template changes have occured.
 
 #### Defined in
 
-[pharkas.component.ts:140](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L140)
+[pharkas.component.ts:141](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L141)
 
 ___
 
@@ -100,7 +100,7 @@ An error has been observed in any observable applied to `bindEffect` or
 
 #### Defined in
 
-[pharkas.component.ts:154](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L154)
+[pharkas.component.ts:155](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L155)
 
 ___
 
@@ -117,7 +117,7 @@ An error has been observed in any observable applied to `bind`, `bindImmediate`,
 
 #### Defined in
 
-[pharkas.component.ts:147](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L147)
+[pharkas.component.ts:148](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L148)
 
 ___
 
@@ -133,7 +133,7 @@ An error has been observed in any observable applied to `bind` or `bindImmediate
 
 #### Defined in
 
-[pharkas.component.ts:160](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L160)
+[pharkas.component.ts:161](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L161)
 
 ## Methods
 
@@ -166,7 +166,7 @@ Default bound observation is combined and throttled to requestAnimationFrame for
 
 #### Defined in
 
-[pharkas.component.ts:296](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L296)
+[pharkas.component.ts:310](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L310)
 
 ___
 
@@ -197,7 +197,7 @@ ___
 
 #### Defined in
 
-[pharkas.component.ts:415](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L415)
+[pharkas.component.ts:429](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L429)
 
 ___
 
@@ -230,7 +230,7 @@ Immediate bindings are neither combined nor throttled.
 
 #### Defined in
 
-[pharkas.component.ts:325](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L325)
+[pharkas.component.ts:339](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L339)
 
 ___
 
@@ -261,7 +261,7 @@ ___
 
 #### Defined in
 
-[pharkas.component.ts:443](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L443)
+[pharkas.component.ts:457](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L457)
 
 ___
 
@@ -290,7 +290,7 @@ Bind an observable to an `@Output()`.
 
 #### Defined in
 
-[pharkas.component.ts:353](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L353)
+[pharkas.component.ts:367](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L367)
 
 ___
 
@@ -320,7 +320,7 @@ value
 
 #### Defined in
 
-[pharkas.component.ts:278](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L278)
+[pharkas.component.ts:292](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L292)
 
 ___
 
@@ -352,7 +352,7 @@ Callback function
 
 #### Defined in
 
-[pharkas.component.ts:367](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L367)
+[pharkas.component.ts:381](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L381)
 
 ___
 
@@ -370,7 +370,7 @@ OnDestroy.ngOnDestroy
 
 #### Defined in
 
-[pharkas.component.ts:524](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L524)
+[pharkas.component.ts:542](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L542)
 
 ___
 
@@ -388,7 +388,7 @@ OnInit.ngOnInit
 
 #### Defined in
 
-[pharkas.component.ts:466](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L466)
+[pharkas.component.ts:480](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L480)
 
 ___
 
@@ -419,7 +419,7 @@ Set an input value
 
 #### Defined in
 
-[pharkas.component.ts:238](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L238)
+[pharkas.component.ts:252](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L252)
 
 ___
 
@@ -451,7 +451,7 @@ Observable
 
 #### Defined in
 
-[pharkas.component.ts:390](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L390)
+[pharkas.component.ts:404](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L404)
 
 ___
 
@@ -475,7 +475,7 @@ Observe an `@Input()` built with `this.setInput`
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `name` | `P` | Name of input |
-| `defaultValue?` | `TDefault` | Default value |
+| `defaultValue?` | `TDefault` \| () => `Observable`<`TDefault`\> | Default value |
 
 #### Returns
 
@@ -485,4 +485,4 @@ Observable
 
 #### Defined in
 
-[pharkas.component.ts:259](https://github.com/WorldMaker/angular-pharkas/blob/a89d096/projects/angular-pharkas/src/pharkas.component.ts#L259)
+[pharkas.component.ts:273](https://github.com/WorldMaker/angular-pharkas/blob/5da8c2b/projects/angular-pharkas/src/pharkas.component.ts#L273)

--- a/projects/angular-pharkas/README.md
+++ b/projects/angular-pharkas/README.md
@@ -118,6 +118,24 @@ export class … {
 
 It will give you console warnings in development builds for non-Observable inputs.
 
+`this.useInput` accepts as an optional second parameter a default value or a function that returns a default
+Observable if an Observable was not bound to the input property prior to `ngOnInit`.
+
+```ts
+export class … {
+  constructor(ref: ChangeDetectorRef, service: SomeService) {
+    super(ref)
+
+    const testInput = this.useInput('testInput', () => service.GetSomeObservable())
+
+    // Use testInput to build observable pipelines…
+  }
+}
+```
+
+Note that using a service class dependency adds tighter coupling for what may be more useful as an always
+provided input, which would be looser coupled.
+
 Also, yeah the string property names and duplication isn't great, but we are working with what Angular gives us.
 
 ## Template Bindings (View Variables, Display Slots, Whatever You Call Them)

--- a/projects/angular-pharkas/package.json
+++ b/projects/angular-pharkas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pharkas",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "peerDependencies": {
     "@angular/common": "^11.1.1",
     "@angular/core": "^11.1.1"

--- a/projects/angular-pharkas/src/pharkas.component.ts
+++ b/projects/angular-pharkas/src/pharkas.component.ts
@@ -197,7 +197,9 @@ export class PharkasComponent<TViewModel> implements OnInit, OnDestroy {
       let valueFunction = defaultValue as (() => Observable<U>) | undefined
       defaultBinding = () => {
         if (!bound && valueFunction) {
-          this[subscription].add(bindInputSubject(name, valueFunction(), subject, bound))
+          this[subscription].add(
+            bindInputSubject(name, valueFunction(), subject, bound)
+          )
           bound = true
           // unset closures just in case
           valueFunction = undefined
@@ -232,7 +234,10 @@ export class PharkasComponent<TViewModel> implements OnInit, OnDestroy {
     T extends TViewModel[P],
     U extends T extends Observable<infer V> ? V : T,
     TDefault extends U
-  >(name: P, defaultValue?: TDefault | (() => Observable<TDefault>)): PharkasInput<U> {
+  >(
+    name: P,
+    defaultValue?: TDefault | (() => Observable<TDefault>)
+  ): PharkasInput<U> {
     let input = this[props].get(name) as PharkasProp<U> | undefined
     if (input && input.type === 'input') {
       return input
@@ -275,7 +280,10 @@ export class PharkasComponent<TViewModel> implements OnInit, OnDestroy {
     T extends TViewModel[P],
     U extends T extends Observable<infer V> ? V : T,
     TDefault extends U
-  >(name: P, defaultValue?: TDefault | (() => Observable<TDefault>)): Observable<U> {
+  >(
+    name: P,
+    defaultValue?: TDefault | (() => Observable<TDefault>)
+  ): Observable<U> {
     const input = this.getOrCreateInput<P, T, U, TDefault>(name, defaultValue)
     return input.observable
   }

--- a/projects/angular-pharkas/test/documentation.test.ts
+++ b/projects/angular-pharkas/test/documentation.test.ts
@@ -30,7 +30,7 @@ describe('works as documented in README', () => {
       constructor(ref: ChangeDetectorRef) {
         super(ref)
 
-        const testInput = this.useInput('testInput', 'Hello World')
+        const testInput = this.useInput('testInput')
 
         // Use testInput to build observable pipelines…
       }
@@ -59,6 +59,44 @@ describe('works as documented in README', () => {
 
     const exampleInstance = new MyExampleComponent(null!)
     expect(exampleInstance).toBeTruthy()
+  })
+
+  it('can have an input with service class default', () => {
+    class SomeService {
+      readonly getSomeObservable = jest.fn(() => of('Hello World'))
+    }
+
+    class MyExampleComponent extends PharkasComponent<MyExampleComponent> {
+      @Input() set testInput(value: Observable<string>) {
+        this.setInput('testInput', value)
+      }
+
+      get test() {
+        return this.bindable<string>('test')
+      }
+
+      constructor(ref: ChangeDetectorRef, service: SomeService) {
+        super(ref)
+
+        const testInput = this.useInput('testInput', () =>
+          service.getSomeObservable()
+        )
+
+        this.bind('test', testInput, 'Default Value')
+      }
+    }
+    expect(MyExampleComponent).toBeDefined()
+
+    const serviceInstance = new SomeService()
+    const exampleInstance = new MyExampleComponent(null!, serviceInstance)
+    expect(exampleInstance).toBeTruthy()
+
+    exampleInstance.ngOnInit()
+
+    expect(serviceInstance.getSomeObservable).toBeCalled()
+    expect(exampleInstance.test).toEqual('Hello World')
+
+    exampleInstance.ngOnDestroy()
   })
 
   it('can have a template binding', () => {


### PR DESCRIPTION
Addresses a common request for "easy component initialization" where an Input may have an obvious default observable injected from a service.

This is not a recommended pattern, but it is a pre-existing common pattern and a frequent ask, so added support for it.

Resolves Set "default" Input binding #27