### PR TITLE
Fix Highcharts export

### DIFF
--- a/projects/angular-pharkas-highcharts/package.json
+++ b/projects/angular-pharkas-highcharts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pharkas-highcharts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "peerDependencies": {
     "@angular/common": "^13.3.0",
     "@angular/core": "^13.3.0",

--- a/projects/angular-pharkas-highcharts/src/chart.component.ts
+++ b/projects/angular-pharkas-highcharts/src/chart.component.ts
@@ -11,7 +11,7 @@ import { observeResize } from 'angular-pharkas/observe-resize'
 import { PharkasComponent } from 'angular-pharkas'
 import { combineLatest, merge, Observable, of } from 'rxjs'
 import { debounceTime, delay, first, switchMap } from 'rxjs/operators'
-import Highcharts, { HIGHCHARTS } from './highcharts'
+import { Highcharts, HIGHCHARTS } from './highcharts'
 
 @Component({
   selector: 'pharkas-chart',

--- a/projects/angular-pharkas-highcharts/src/highcharts.ts
+++ b/projects/angular-pharkas-highcharts/src/highcharts.ts
@@ -1,9 +1,9 @@
 import { InjectionToken } from '@angular/core'
-import * as Highcharts from 'highcharts'
+import * as H from 'highcharts'
 import HighchartsStock from 'highcharts/modules/stock'
 
-HighchartsStock(Highcharts)
+HighchartsStock(H)
 
-export default Highcharts
+export const Highcharts = H
 
 export const HIGHCHARTS = new InjectionToken<typeof Highcharts>('highcharts')

--- a/projects/angular-pharkas-highcharts/src/stock-chart.component.ts
+++ b/projects/angular-pharkas-highcharts/src/stock-chart.component.ts
@@ -17,7 +17,7 @@ import {
   shareReplay,
   switchMap,
 } from 'rxjs/operators'
-import Highcharts, { HIGHCHARTS } from './highcharts'
+import { Highcharts, HIGHCHARTS } from './highcharts'
 
 @Component({
   selector: 'pharkas-stockchart',


### PR DESCRIPTION
The Highcharts export was a default export and would have been hard to work with as such.

Because this is a fix to how the API with respect to how it was documented (the documentation was correct, the implementation was wrong), bumping semver PATCH rather than semver MAJOR, but it would be a breaking change otherwise.