### PR TITLE
Add bindSuspense (#52)

### DIFF
--- a/projects/angular-pharkas/README.md
+++ b/projects/angular-pharkas/README.md
@@ -179,10 +179,42 @@ managing the DOM. (If you were to build a "push" alternative to Angular's Reacti
 for instance.) In such cases there are "Immediate" variants of bindings. You may not need them,
 and the defaults should do what you need in most cases.
 
-### Error Blinkenlights
+### Suspense
+
+A component may bind a suspense observable:
+
+```ts
+@Component({
+  // …
+})
+export class MyExampleComponent extends PharkasComponent<MyExampleComponent> {
+  constructor(ref: ChangeDetectorRef) {
+    super(ref)
+
+    // Build some observables…
+
+    this.bindSuspense(someSuspenseObservable)
+  }
+}
+```
+
+When this `Observable<boolean>` emits `true`, template change notifications are skipped for
+non-immediate template bindings until the next `false` is emitted. The `pharkasSuspense`
+blinkenlight reflects this suspense state.
+
+This may be useful for instance while a loading operation is taking place to display some
+simple loading indicator and reduce "UI bouncing" with intermediate states.
+
+Note that this only suspends normal change detection pushes. It will not entirely eliminate
+such "UI bouncing" as for instance an immediate binding will still trigger Angular change
+detection.
+
+### Blinkenlights
 
 Pharkas provides a set of blinkenlights (lights intended to blink a status) for very basic error
-status indication. These are "last chance error reporting" blinkenlights for generic error
+status indication or suspense states (such as loading).
+
+The error blinkenlights are "last chance error reporting" blinkenlights for generic error
 situations when any observable provided to `bind` or `bindEffect` or an "Immediate" variant of
 such has thrown an error.
 

--- a/projects/angular-pharkas/package.json
+++ b/projects/angular-pharkas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pharkas",
-  "version": "5.2.1",
+  "version": "6.0.0",
   "peerDependencies": {
     "@angular/common": "^13.3.0",
     "@angular/core": "^13.3.0"

--- a/projects/angular-pharkas/src/pharkas.component.ts
+++ b/projects/angular-pharkas/src/pharkas.component.ts
@@ -577,17 +577,22 @@ export class PharkasComponent<TViewModel> implements OnInit, OnDestroy {
       }
     }
     if (observables.length) {
-      const displayObservable = combineLatest([
-        concat(
-          of([false, false]),
-          this[pharkas].suspense.asObservable().pipe(pairwise())
-        ),
-        merge(...observables),
-      ]).pipe(
-        filter(
-          ([[lastSuspense, suspense]]) =>
-            !suspense || (lastSuspense && lastSuspense !== suspense)
-        ),
+      const merged = merge(...observables)
+      const suspensed = this[pharkas].suspenseBound
+        ? combineLatest([
+            concat(
+              of([false, false]),
+              this[pharkas].suspense.asObservable().pipe(pairwise())
+            ),
+            merged,
+          ]).pipe(
+            filter(
+              ([[lastSuspense, suspense]]) =>
+                !suspense || (lastSuspense && lastSuspense !== suspense)
+            )
+          )
+        : merged
+      const displayObservable = suspensed.pipe(
         debounceTime(0, animationFrameScheduler),
         share()
       )

--- a/projects/angular-pharkas/test/documentation.test.ts
+++ b/projects/angular-pharkas/test/documentation.test.ts
@@ -124,6 +124,23 @@ describe('works as documented in README', () => {
     expect(exampleInstance.testDisplay).toEqual('Hello World')
   })
 
+  it('can have a suspense binding', () => {
+    class MyExampleComponent extends PharkasComponent<MyExampleComponent> {
+      constructor(ref: ChangeDetectorRef) {
+        super(ref)
+
+        const suspense = of(true)
+
+        this.bindSuspense(suspense)
+      }
+    }
+    expect(MyExampleComponent).toBeDefined()
+
+    const exampleInstance = new MyExampleComponent(null!)
+    expect(exampleInstance).toBeTruthy()
+    expect(exampleInstance.pharkasSuspense).toBeTruthy()
+  })
+
   it('can define a callback', () => {
     class MyExampleComponent extends PharkasComponent<MyExampleComponent> {
       // Type only, no implementation:

--- a/projects/test-app/src/pharkas-test.component.ts
+++ b/projects/test-app/src/pharkas-test.component.ts
@@ -17,6 +17,13 @@ import { scan } from 'rxjs/operators'
     [class.is-warning]="highlighted"
   >
     Hello {{ testDisplay }}
+    <progress
+      *ngIf="pharkasSuspense"
+      class="progress is-small is-primary"
+      max="100"
+    >
+      Updating
+    </progress>
   </div>`,
 })
 export class PharkasTestComponent extends PharkasComponent<PharkasTestComponent> {
@@ -55,15 +62,18 @@ export class PharkasTestComponent extends PharkasComponent<PharkasTestComponent>
     const click = this.useCallback('handleClick')
     this.bindOutput(this.mickey, click)
 
+    const highlighted = click.pipe(scan((acc) => !acc, false as boolean))
+
     // Simple "state" logic to toggle a highlight on click
-    this.bind(
-      'highlighted',
-      click.pipe(scan((acc) => !acc, false as boolean)),
-      false
-    )
+    this.bind('highlighted', highlighted, false)
+
+    // Suspend while highlighted
+    this.bindSuspense(highlighted)
 
     // Dumb console log test of handleClick
     this.bindEffect(click, ([mouseEvent]) => console.log('clicked', mouseEvent))
+
+    // this.bindEffect(this.pharkasChangeNotifications, () => console.log('tick'))
 
     console.log(this)
   }


### PR DESCRIPTION
`bindSuspense` is a Pharkas tool built from cheap and simple RxJS operators that acts somewhat similar to user-facing behaviors from React's complex Suspense engine.

You bind a suspense `Observable<boolean>`, which when `true` is emitted will pause Angular change detection for all non-immediate template bindings and gets reflected to a `pharkasSuspense` blinkenlight.

This will be useful in instances such as complex loading or data analysis situations to slow down (but not stop) Angular from updating "intermediate" template states. The blinkenlight can be used to show a loading indicator or other overlay.

Resolves #52